### PR TITLE
Add a helpful description to the role

### DIFF
--- a/role.tf
+++ b/role.tf
@@ -27,6 +27,7 @@ data "aws_iam_policy_document" "assume_role_doc" {
 # The IAM role
 resource "aws_iam_role" "the_role" {
   name               = "ReadCert-${var.hostname}"
+  description        = "Allows fetching the certificate data for ${var.hostname} from the ${var.cert_bucket_name} S3 bucket."
   assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
 }
 


### PR DESCRIPTION
A small change, sure, but helpful when you are looking at roles in the AWS console.