### PR TITLE
Update the role name to agree with what we are using now in the COOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,16 @@ This meta-role requires a permission policy similar to the following:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
-| account_ids | AWS account IDs that are to be allowed to assume the role | list(string) | [] | no |
-| cert_bucket_name | The name of the AWS S3 bucket where certificates are stored | string | | yes |
+| account_ids | AWS account IDs that are to be allowed to assume the role. | list(string) | [] | no |
+| cert_bucket_name | The name of the AWS S3 bucket where certificates are stored. | string | | yes |
 | cert_path | The path to the certificates in the AWS S3 bucket.  For example, the certificate files for site.example.com are expected to live at <cert_bucket_path>/site.example.com/*. | string | "live" | no |
-| hostname | The FQDN corresponding to the certificate to be read (e.g. site.example.com) | string | | yes |
+| hostname | The FQDN corresponding to the certificate to be read (e.g. site.example.com). | string | | yes |
 
 ## Outputs ##
 
 | Name | Description |
 |------|-------------|
-| role | The IAM role to be used for reading certificate data for the specified hostname |
+| role | The IAM role to be used for reading certificate data for the specified hostname. |
 
 ## Contributing ##
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This meta-role requires a permission policy similar to the following:
                 "iam:PutRolePolicy",
                 "iam:GetRolePolicy"
             ],
-            "Resource": "arn:aws:iam::123456789012:role/ReadCert-*"
+            "Resource": "arn:aws:iam::123456789012:role/CertificateReadOnly-*"
         }
     ]
 }
@@ -67,7 +67,7 @@ This meta-role requires a permission policy similar to the following:
 
 | Name | Description |
 |------|-------------|
-| arn | The ARN corresponding to the IAM role to be used for reading certificate data for the specified hostname |
+| role | The IAM role to be used for reading certificate data for the specified hostname |
 
 ## Contributing ##
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "arn" {
-  value       = aws_iam_role.the_role.arn
-  description = "The ARN corresponding to the IAM role to be used for reading certificate data for the specified hostname"
+output "role" {
+  value       = aws_iam_role.the_role
+  description = "The IAM role to be used for reading certificate data for the specified hostname."
 }

--- a/role.tf
+++ b/role.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "assume_role_doc" {
 
 # The IAM role
 resource "aws_iam_role" "the_role" {
-  name               = "ReadCert-${var.hostname}"
+  name               = "CertificateReadOnly-${var.hostname}"
   description        = "Allows fetching the certificate data for ${var.hostname} from the ${var.cert_bucket_name} S3 bucket."
   assume_role_policy = data.aws_iam_policy_document.assume_role_doc.json
 }


### PR DESCRIPTION
## 🗣 Description

To provide more consistency, we changed the role name to `CertificateReadOnly-*` as we have been working on the COOL.  This pull request amends this Terraform module accordingly.

## 💭 Motivation and Context

If the role name doesn't agree with what we are using in the COOL then the role will never work.

## 🧪 Testing

I was able to perform a test deployment to the COOL using this code.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
